### PR TITLE
feat: added an option to leave miniwindows the same as the official client

### DIFF
--- a/modules/client_options/game.otui
+++ b/modules/client_options/game.otui
@@ -7,6 +7,10 @@ OptionPanel
       visible: false
 
   OptionCheckBox
+    id: moveWindowsToPanel
+    !text: tr('Move windows to panel')
+    
+  OptionCheckBox
     id: autoChaseOverride
     !text: tr('Allow auto chase override')
 

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -66,7 +66,8 @@ local defaultOptions = {
 
   profile = 1,
   
-  antialiasing = true
+  antialiasing = true,
+  moveWindowsToPanel = false
 }
 
 local optionsWindow
@@ -350,6 +351,8 @@ function setOption(key, value, force)
     generalPanel:getChildById('walkCtrlTurnDelayLabel'):setText(tr('Walk delay after ctrl turn: %s ms', value))  
   elseif key == "antialiasing" then
     g_app.setSmooth(value)
+  elseif key == 'moveWindowsToPanel' then
+    g_settings.set('moveWindowsToPanel', true)
   end
 
   -- change value for keybind updates

--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -305,6 +305,7 @@ function UIMiniWindow:onDragMove(mousePos, mouseMoved)
     self.setMovedChildMargin(self.movedOldMargin or 0)
     self.movedWidget = nil
   end
+  self.setMovedChildMargin(0)
 
   return UIWindow.onDragMove(self, mousePos, mouseMoved)
 end

--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -228,16 +228,42 @@ function UIMiniWindow:onDragEnter(mousePos)
 end
 
 function UIMiniWindow:onDragLeave(droppedWidget, mousePos)
-  if self.movedWidget then
-    self.setMovedChildMargin(self.movedOldMargin or 0)
-    self.movedWidget = nil
-    self.setMovedChildMargin = nil
-    self.movedOldMargin = nil
-    self.movedIndex = nil
-  end
 
-  UIWindow:onDragLeave(self, droppedWidget, mousePos)
-  self:saveParent(self:getParent())
+  if g_settings.getBoolean('moveWindowsToPanel') then
+      local children = rootWidget:recursiveGetChildrenByMarginPos(mousePos)
+      local dropInPanel = 0
+   
+      for i=1,#children do
+          local child = children[i]
+          if child:getId() == 'gameLeftPanel' or child:getId() == 'gameRightPanel' then
+              dropInPanel = 1
+          end
+      end
+
+      if dropInPanel == 0 then
+          tmpp = self
+              if(modules.game_interface.getLeftPanel():isVisible()) then
+                  if modules.game_interface.getRootPanel():getWidth() / 2 < mousePos.x then
+                      addEvent(function() tmpp:setParent(modules.game_interface.getRightPanel()) end)
+                  else
+                      addEvent(function() tmpp:setParent(modules.game_interface.getLeftPanel()) end)
+                  end
+              else
+                  addEvent(function() tmpp:setParent(modules.game_interface.getRightPanel()) end)
+          end
+      end
+   
+  else
+      if self.movedWidget then
+        self.setMovedChildMargin(self.movedOldMargin or 0)
+        self.movedWidget = nil
+        self.setMovedChildMargin = nil
+        self.movedOldMargin = nil
+        self.movedIndex = nil
+      end
+   
+      self:saveParent(self:getParent())
+  end
 end
 
 function UIMiniWindow:onDragMove(mousePos, mouseMoved)


### PR DESCRIPTION
# Description

Added an option to leave miniwidows the same as the official client, limiting the fixed space within the panels
![image](https://github.com/opentibiabr/otcv8/assets/12704707/0311fd42-2e3a-4f59-9c94-de01b45a9f3d)
![image](https://github.com/opentibiabr/otcv8/assets/12704707/0afec066-390e-4256-832f-49a035362fa9)


When activated, the behavior will be the same as the official client. Placing the miniwindow in a panel
![image](https://github.com/opentibiabr/otcv8/assets/12704707/ac1413cd-1f25-4f18-9b33-d2061a4bfaba)




## Behaviour
### **Actual**

If you drag a miniwindow it has a unique behavior, always staying where it is dropped

### **Expected**

With the change, the otclient starts to have an additional behavior, and may have the same characteristics as the official client.
## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client: 
  - Operating System: 

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
